### PR TITLE
ユーザー管理機能：削除できない問題の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
-  before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :configure_permitted_parameters2, if: :devise_controller?
+  before_action :configure_permitted_parameters_sign_up, if: :devise_controller?
+  before_action :configure_permitted_parameters_account_update, if: :devise_controller?
 
   private
 
@@ -11,11 +11,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def configure_permitted_parameters
+  def configure_permitted_parameters_sign_up
     devise_parameter_sanitizer.permit(:sign_up,keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_date])
   end
 
-  def configure_permitted_parameters2
+  def configure_permitted_parameters_account_update
     devise_parameter_sanitizer.permit(:account_update,keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_date])
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :words
+  has_many :words, dependent: :destroy
 
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   VALID_NAME_REGEX = /\A[ぁ-んァ-ヶ一-龥々ー]+\z/

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -108,7 +108,7 @@
       <%= button_to "ユーザーアカウントの削除",
           registration_path(resource_name),
           class:"delete-gray-btn",
-          data: { confirm: "あなたのアカウントを削除してもよろしいですか?削除した場合、このサイトから退会することとなります。" },
+          data: { confirm: "あなたのアカウントを削除してもよろしいですか?削除した場合、このサイトから退会することとなり、登録したワードも全て削除されます。" },
           method: :delete %>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,14 +11,14 @@
       <label class="form-text">ニックネーム</label>
       <span class="indispensable">必須</span>
     </div>
-    <%= f.text_area :nickname, class:"input-default", id:"nickname", placeholder:"", maxlength:"40" %>
+    <%= f.text_area :nickname, class:"input-default", id:"nickname", placeholder:"", maxlength:"40", autofocus: true %>
   </div>
   <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">メールアドレス</label>
       <span class="indispensable">必須</span>
     </div>
-    <%= f.email_field :email, class:"input-default", id:"email", placeholder:"", autofocus: true %>
+    <%= f.email_field :email, class:"input-default", id:"email", placeholder:"" %>
   </div>
   <div class="form-group">
     <div class='form-text-wrap'>


### PR DESCRIPTION
# What
ユーザーモデルのアソシエーションに、dependent: :destroyオプションを追加

# Why
ワード登録機能を追加後、ユーザー削除が行われた場合に、関連するワードも削除されなければならないため。
