### PR TITLE
エラー回避：新規登録画面がエラーになる問題

### DIFF
--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -26,9 +26,9 @@
       <label class="word_edit_title">サービス</label>
       <%= form.collection_select(:service_category_id, ServiceCategory.all, :id, :name, options ={selected: @word.service_category_id}, {class:"word_edit_field", id:""}) %>
       <label class="word_edit_title">登録日時（編集不可）</label>
-      <%= form.text_field :created_at, readonly: true, value: l(@word.created_at), class:"word_edit_field" %>
+      <%= form.text_field :created_at, readonly: true, value: @word.created_at, class:"word_edit_field" %>
       <label class="word_edit_title">更新日時（編集不可）</label>
-      <%= form.text_field :updated_at, readonly: true, value: l(@word.updated_at), class:"word_edit_field" %>
+      <%= form.text_field :updated_at, readonly: true, value: @word.updated_at, class:"word_edit_field" %>
       <%= form.submit '保存',class:"word_edit_save_button", data: { confirm: "このワードを更新します。更新してもよろしいですか。" } %>
     <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,8 +10,6 @@ module WordExperience
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.i18n.default_locale = :ja
-    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,0 @@
-ja:
-  time:
-    formats:
-      default: "%Y/%m/%d %H:%M:%S"


### PR DESCRIPTION
# What
ロールバック

# Why
「登録日時、更新日時の表記を変更」で反映させた内容によって、ユーザーの新規登録ができない状態となっていたため、反映内容を修正（ロールバック）する必要があったから