### PR TITLE
日時の表記修正

### DIFF
--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -26,9 +26,9 @@
       <label class="word_edit_title">サービス</label>
       <%= form.collection_select(:service_category_id, ServiceCategory.all, :id, :name, options ={selected: @word.service_category_id}, {class:"word_edit_field", id:""}) %>
       <label class="word_edit_title">登録日時（編集不可）</label>
-      <%= form.text_field :created_at, readonly: true, value: @word.created_at, class:"word_edit_field" %>
+      <%= form.text_field :created_at, readonly: true, value: @word.created_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
       <label class="word_edit_title">更新日時（編集不可）</label>
-      <%= form.text_field :updated_at, readonly: true, value: @word.updated_at, class:"word_edit_field" %>
+      <%= form.text_field :updated_at, readonly: true, value: @word.updated_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
       <%= form.submit '保存',class:"word_edit_save_button", data: { confirm: "このワードを更新します。更新してもよろしいですか。" } %>
     <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module WordExperience
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
# What
日本の日時となるよう、日本のタイムゾーンに設定
日時の表記フォーマットを変更（strftimeを使用）

# Why
主に日本ユーザーがメインとなるため、表記の時刻を日本時間にする必要があったため。

# 補足事項
 ja.ymlファイルを用いて、実装する方法は取りやめた。理由としては、システムが受ける影響範囲が把握できず、全体的な見直しが発生してしまうことになるため。
またstrftimeを使用する方法は、手間がかかるが、今回のアプリはそれほど大きなアプリではないため、採用することとなった。