### PR TITLE
ワード情報が見やすいようデザインを修正

### DIFF
--- a/app/assets/stylesheets/word/index.css
+++ b/app/assets/stylesheets/word/index.css
@@ -1,64 +1,48 @@
 .word_theme {
   color: #444444;
   text-align: center;
+  margin-bottom: 20px;
   font-size: 30px;
+  color: #6c757d;
 }
 
 .word_list{
   text-align: center;
 }
 
-.word_title_header{
-  display: flex;
-  justify-content: center;
-  font-size: 20px;
-  margin-top: 25px;
-}
-
-.word_title_header_name{
-  
-}
-
-.word_title_header_main_category{
-  margin-left: 80px;
-}
-
-.word_title_header_service_category{
-  margin-left: 100px;
-  margin-right: 100px;
-}
-
 .word_name{
   border-radius: 5px;
-  margin-top: 7px;
-  padding: 3px;
+  padding: 8px;
   font-size: 15px;
   border: solid 0.1px black;
+  background-color: #FFFFFF;
+  text-align: center;
 }
 
 .word_main_category{
   border-radius: 5px;
-  margin-left: 3px;
-  margin-top: 7px;
-  padding: 3px;
+  padding: 8px;
+  margin-left: 5px;
   font-size: 15px;
   border: solid 0.1px black;
+  background-color: #FFFFFF;
+  text-align: center;
 }
 
 .word_service_category{
   border-radius: 5px;
-  margin-left: 3px;
-  margin-top: 7px;
-  padding: 3px;
+  padding: 8px;
+  margin-left: 5px;
   font-size: 15px;
   border: solid 0.1px black;
+  background-color: #FFFFFF;
+  text-align: center;
 }
 
 .word_button_edit{
   border-radius: 5px;
-  margin-left: 3px;
-  margin-top: 1px;
-  padding: 7px 20px;
+  padding: 8px 20px;
+  margin-left: 5px;
   font-size: 15px;
   background-color: rgb(52, 152, 219);
   color: #EEEEEE;
@@ -76,26 +60,6 @@
   text-align: center;
 }
 
-.word_new_title_header{
-  margin-top: 40px;
-  display: flex;
-  justify-content: center;
-  font-size: 20px;
-}
-
-.word_new_title_header_name{
-  
-}
-
-.word_new_title_header_main_category{
-  margin-left: 100px;
-}
-
-.word_new_title_header_service_category{
-  margin-left: 30px;
-  
-}
-
 .word_new_record{
   margin-bottom: 15px;
 }
@@ -103,31 +67,33 @@
 .word_new_name{
   border-radius: 5px;
   padding: 8px;
-  font-size: 16px;
+  font-size: 15px;
   border: solid 0.1px black;
+  text-align: left;
 }
 
 .word_new_main_category{
   border-radius: 5px;
   margin-left: 3px;
   padding: 10px;
-  font-size: 16px;
+  font-size: 15px;
   border: solid 0.1px black;
+  text-align: center;
 }
 
 .word_new_service_category{
   border-radius: 5px;
   margin-left: 3px;
   padding: 10px;
-  font-size: 16px;
+  font-size: 15px;
   border: solid 0.1px black;
+  text-align: center;
 }
 
 .word_new_button_save{
   border-radius: 5px;
   padding: 8px 32px;
-  margin-top: 10px;
-  font-size: 17px;
+  font-size: 15px;
   background-color: rgb(52, 152, 219);
   color: #EEEEEE;
   border: none;
@@ -147,16 +113,19 @@
 
 .word_edit_title{
   margin-bottom: 5px;
-  font-size: 18px;
+  font-size: 15px;
+  color: #6c757d;
+  font-weight: 600;
 }
 
 .word_edit_field{
-  padding: 5px 10px;
-  margin-bottom: 15px;
-  font-size: 16px;
+  padding: 8px;
+  margin-bottom: 18px;
+  font-size: 15px;
   width: 300px;
   border: solid 0.1px black;
   border-radius: 5px;
+  text-align: center;
 }
 
 .word_edit_save_button{

--- a/app/models/main_category.rb
+++ b/app/models/main_category.rb
@@ -1,6 +1,6 @@
 class MainCategory < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---' },
+    { id: 1, name: '-カテゴリを選択必須-' },
     { id: 2, name: 'ゲーム' },
     { id: 3, name: 'コメディー' },
     { id: 4, name: 'スポーツ' },

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -1,6 +1,6 @@
 class ServiceCategory < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---' },
+    { id: 1, name: '--サービスを選択必須--' },
     { id: 2, name: 'YouTube' },
     { id: 3, name: 'Twitter' },
     { id: 4, name: 'Facebook' },

--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -20,15 +20,15 @@
       <%= render 'shared/error_messages', model: form.object %>
 
       <label class="word_edit_title">ワードの名称</label>
-      <%= form.text_field :name, value: @word.name, class:"word_edit_field", maxlength: 30 %>
+      <%= form.text_field :name, value: @word.name, class:"word_edit_field", maxlength: 30, placeholder:"4文字以上、30文字以下" %>
       <label class="word_edit_title">カテゴリ</label>
       <%= form.collection_select(:main_category_id, MainCategory.all, :id, :name, options ={selected: @word.main_category_id}, {class:"word_edit_field", id:""}) %>
       <label class="word_edit_title">サービス</label>
       <%= form.collection_select(:service_category_id, ServiceCategory.all, :id, :name, options ={selected: @word.service_category_id}, {class:"word_edit_field", id:""}) %>
       <label class="word_edit_title">登録日時（編集不可）</label>
-      <%= form.text_field :created_at, readonly: true, value: @word.created_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
+      <%= form.text_field :created_at, readonly: true, disabled: true, value: @word.created_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
       <label class="word_edit_title">更新日時（編集不可）</label>
-      <%= form.text_field :updated_at, readonly: true, value: @word.updated_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
+      <%= form.text_field :updated_at, readonly: true, disabled: true, value: @word.updated_at.strftime('%Y/%m/%d %H:%M:%S'), class:"word_edit_field" %>
       <%= form.submit '保存',class:"word_edit_save_button", data: { confirm: "このワードを更新します。更新してもよろしいですか。" } %>
     <% end %>
 

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -8,23 +8,19 @@
   </div>
   <div class="main_screen">
     <h3 class="word_theme">
-      "ワード"一覧
+      "ワード" 一覧
     </h3>
-
-    <div class="word_title_header">
-      <div class="word_title_header_name">ワードの名称</div>
-      <div class="word_title_header_main_category">カテゴリ</div>
-      <div class="word_title_header_service_category">サービス</div>
-    </div>
-
+    
     <%= form_with class: "word_list", local: true do |form| %>
       <% @words.each do |word| %>
-        <%= form.text_field :name, readonly: true, value: word.name, class: "word_name" %>
-        <%= form.text_field :main_category_id, readonly: true, value: @main_category.find(word.main_category_id).name, class: "word_main_category" %>
-        <%= form.text_field :service_category_id, readonly: true, value: @service_category.find(word.service_category_id).name, class: "word_service_category" %>
+        <hr size="1" width="98%" noshade="">
+        <%= form.text_field :name, readonly: true, disabled: true, size: 30, value: word.name, class: "word_name" %>
+        <%= form.text_field :main_category_id, readonly: true, disabled: true, size: 15, value: @main_category.find(word.main_category_id).name, class: "word_main_category" %>
+        <%= form.text_field :service_category_id, readonly: true, disabled: true, size: 15, value: @service_category.find(word.service_category_id).name, class: "word_service_category" %>
         <%= link_to '編集', edit_user_word_path(word.user_id,word), class: "word_button_edit" %>
         <br>
       <% end %>
+      <hr size="1" width="98%" noshade="">
     <% end %>
   </div>
 </div>

--- a/app/views/words/new.html.erb
+++ b/app/views/words/new.html.erb
@@ -8,27 +8,22 @@
   </div>
   <div class="main_screen">
     <h3 class="word_theme">
-      "ワード"新規登録
+      "ワード" 新規登録
     </h3>
-
-    <div class="word_new_title_header">
-      <div class="word_new_title_header_name">ワードの名称</div>
-      <div class="word_new_title_header_main_category">カテゴリ</div>
-      <div class="word_new_title_header_service_category">サービス</div>
-    </div>
-
 
     <%= form_with class: "word_new_list", modele: @words, url: user_words_path, method: :post, local: true do |form| %>
       <% @words.collection.each do |word| %>
         <%= fields_for 'words[]', word do |field| %>
           <div class="word_new_record">
-            <%= field.text_field :name , class: "word_new_name", maxlength: 30 %>
-            <%= field.collection_select(:main_category_id, MainCategory.all, :id, :name, {}, {class:"word_new_main_category", id:""}) %>
+            <hr size="1" width="99%">
+            <%= field.text_field :name , class: "word_new_name", maxlength: 30, placeholder:"ワード(4文字以上、30文字以下)" %>
+            <%= field.collection_select(:main_category_id, MainCategory.all, :id, :name, {}, {class:"word_new_main_category", id:"", placeholder:"例)3"}) %>
             <%= field.collection_select(:service_category_id, ServiceCategory.all, :id, :name, {}, {class:"word_new_service_category", id:""}) %>
           </div>
         <% end %>
       <% end %>
-        <%= form.submit '登録',class:"word_new_button_save", data: { confirm: "このワードを登録します。更新してもよろしいですか。" } %>
+      <hr size="1" width="99%">
+      <%= form.submit '登録',class:"word_new_button_save", data: { confirm: "このワードを登録します。更新してもよろしいですか。" } %>
     <% end %>
 
   </div>


### PR DESCRIPTION
# What
ワード情報が見やすいようデザインを修正
・ラインを追加
・placeholder追加
・オブジェクトのサイズ変更
・不必要なHTMLタグ、CSSのセレクタなどを削除

# Why
ユーザーが見やすいデザインにする必要があったため。
またワード交換機能でも同じようなデザインを採用するため、先に状態をリファクタリングする必要があったから。