### PR TITLE
クリップボードへのコピー機能を追加

### DIFF
--- a/app/assets/stylesheets/word/index.css
+++ b/app/assets/stylesheets/word/index.css
@@ -14,22 +14,25 @@
   border-radius: 5px;
   padding: 8px;
   font-size: 15px;
+  color: #000000;
   border: solid 0.1px black;
   background-color: #FFFFFF;
   text-align: center;
+  cursor: copy;
 }
 
-.word_main_category{
+.word_category{
   border-radius: 5px;
   padding: 8px;
   margin-left: 5px;
   font-size: 15px;
+  color: #6c757d;
   border: solid 0.1px black;
   background-color: #FFFFFF;
   text-align: center;
 }
 
-.word_service_category{
+.word_category{
   border-radius: 5px;
   padding: 8px;
   margin-left: 5px;
@@ -72,20 +75,12 @@
   text-align: left;
 }
 
-.word_new_main_category{
+.word_new_category{
   border-radius: 5px;
   margin-left: 3px;
   padding: 10px;
   font-size: 15px;
-  border: solid 0.1px black;
-  text-align: center;
-}
-
-.word_new_service_category{
-  border-radius: 5px;
-  margin-left: 3px;
-  padding: 10px;
-  font-size: 15px;
+  color: #000000;
   border: solid 0.1px black;
   text-align: center;
 }

--- a/app/javascript/copy_clipboard.js
+++ b/app/javascript/copy_clipboard.js
@@ -1,0 +1,19 @@
+function copyToClipboard (tagValue) {
+    try {
+      navigator.clipboard.writeText(tagValue);
+    } catch (error) {
+      alert('コピーに失敗しました');
+    }
+}
+
+function copy_word (){
+  const textForm = document.querySelectorAll(".word_name");
+  textForm.forEach(function (button) {
+    button.addEventListener("click", (e) => {
+      e.preventDefault();
+      copyToClipboard(button.value)
+    });
+  });
+};
+
+window.addEventListener('load', copy_word);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("channels")
 require("shared/sidebar")
 import "bootstrap"
 import "../stylesheets/application"
+require("copy_clipboard.js")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -10,13 +10,13 @@
     <h3 class="word_theme">
       "ワード" 一覧
     </h3>
-    
+
     <%= form_with class: "word_list", local: true do |form| %>
       <% @words.each do |word| %>
         <hr size="1" width="98%" noshade="">
-        <%= form.text_field :name, readonly: true, disabled: true, size: 30, value: word.name, class: "word_name" %>
-        <%= form.text_field :main_category_id, readonly: true, disabled: true, size: 15, value: @main_category.find(word.main_category_id).name, class: "word_main_category" %>
-        <%= form.text_field :service_category_id, readonly: true, disabled: true, size: 15, value: @service_category.find(word.service_category_id).name, class: "word_service_category" %>
+        <%= form.text_field :name, readonly: true, size: 30, value: word.name, class: "word_name" %>
+        <%= form.text_field :main_category_id, readonly: true, disabled: true, size: 15, value: @main_category.find(word.main_category_id).name, class: "word_category" %>
+        <%= form.text_field :service_category_id, readonly: true, disabled: true, size: 15, value: @service_category.find(word.service_category_id).name, class: "word_category" %>
         <%= link_to '編集', edit_user_word_path(word.user_id,word), class: "word_button_edit" %>
         <br>
       <% end %>

--- a/app/views/words/new.html.erb
+++ b/app/views/words/new.html.erb
@@ -17,8 +17,8 @@
           <div class="word_new_record">
             <hr size="1" width="99%">
             <%= field.text_field :name , class: "word_new_name", maxlength: 30, placeholder:"ワード(4文字以上、30文字以下)" %>
-            <%= field.collection_select(:main_category_id, MainCategory.all, :id, :name, {}, {class:"word_new_main_category", id:"", placeholder:"例)3"}) %>
-            <%= field.collection_select(:service_category_id, ServiceCategory.all, :id, :name, {}, {class:"word_new_service_category", id:""}) %>
+            <%= field.collection_select(:main_category_id, MainCategory.all, :id, :name, {}, {class:"word_new_category", id:"", placeholder:"例)3"}) %>
+            <%= field.collection_select(:service_category_id, ServiceCategory.all, :id, :name, {}, {class:"word_new_category", id:""}) %>
           </div>
         <% end %>
       <% end %>


### PR DESCRIPTION
# What
ワード一覧からワードをクリックした際に、クリップボードにコピーできる機能を追加

# Why
ワードを利活用してもらうために、コピーが簡単にできる機能を実装する必要があったため

# 補足
実現したいことが困難だったことが多かったため、後日、jQueryを用いた実装を検討している。