### PR TITLE
調査：ワードポイントがEC2上で機能しない問題：コメント

### DIFF
--- a/app/controllers/concerns/point_method.rb
+++ b/app/controllers/concerns/point_method.rb
@@ -12,11 +12,11 @@ module PointMethod
 
   def set_word_point_display
     if !user_signed_in?
-      @word_point = '一部編集'
+      @word_point = '---'
     elsif WordPoint.exists?(user_id: current_user.id)
       @word_point = WordPoint.find_by(user_id: current_user.id).point
     else
-      @word_point = '未登録'
+      @word_point = '0'
     end
   end
 


### PR DESCRIPTION
# What
プロセスをkillして、再度デプロイを行った

# Why
直接的な原因が不明だが、上記対応をすることで、EC2へデプロイすることができたため（当分の間は、デプロイした際に動作を様子見）

# 補足事項
プロセスをkillする前に、行ったことは以下の通り。
・WordPointの処理をBefore_actionで呼び出していることが原因ではないか？→デプロイ後、まれに処理がうまくいったことがあったため、直接的な原因ではないと判断。
・ログを確認→WordPointの処理で異常系が出ていることはなかった。
何度もデプロイを行ったところ、サイドバー、ヘッダー、新規登録画面、ログイン画面のデザインが崩れてしまったことがあった。（なおWordPointの処理も正常ではなかった）以下のエラーが発生していたが、原因がわからず、現在も表示されている。
      01 WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
      01 Entrypoints:
      01   application (305 KiB)
      01       css/application-ef326e79.css
      01       js/application-21ca92f0a0c11f32f7c9.js
      01
      01
      01 WARNING in webpack performance recommendations:
      01 You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
      01 For more info visit https://webpack.js.org/guides/code-splitting/
      01 Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--7-1!node_modules/postcss-loader/src/index.js??ref--7-2!node_modules/sass-loader/dist/cjs.js??ref--7-3!app/javascript/s…
      01     Entrypoint mini-css-extract-plugin = *
      01     [0] ./node_modules/css-loader/dist/cjs.js??ref--7-1!./node_modules/postcss-loader/src??ref--7-2!./node_modules/sass-loader/dist/cjs.js??ref--7-3!./app/javascript/stylesheets/application.…
      01         + 1 hidden module
原因がわからず、デザインを崩れてしまったため、プロセスをkillしてみて、再度デプロイしてみたところ、正常に動作することが確認できた。

# 原因（エビデンスはなし）
状況から、自動デプロイしたものの、EC2側に正しく反映ができていなかったものと思われる。対処法としては、プロセスを手動でkillすることが現状考えられる。