### PR TITLE
ワードの交換、編集、削除時のエラーメッセージ機能を実装

### DIFF
--- a/app/assets/stylesheets/shared/error_messages.css
+++ b/app/assets/stylesheets/shared/error_messages.css
@@ -9,3 +9,10 @@
   list-style: disc;
   color: rgb(182, 48, 0);
 }
+
+.alert_message{
+  text-align: center;
+  font-size: 17px;
+  background-color: rgba(231, 93, 93, 0.4);
+  color: #222222;
+}

--- a/app/assets/stylesheets/shared/main.css
+++ b/app/assets/stylesheets/shared/main.css
@@ -15,7 +15,7 @@
   height: 100%;
   background-color: #fcf5f3;
   margin-top: 20px;
-  padding: 16px;
+  padding: 16px 130px;
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -30,6 +30,7 @@
   width: auto;
   height: 80px;
   padding: 8px 32px;
+  margin-bottom: 10px;
   background-color: #FFFFFF;
   border-radius: 5px;
   border: 1px double #efe2ce;

--- a/app/controllers/concerns/error_message_flash.rb
+++ b/app/controllers/concerns/error_message_flash.rb
@@ -11,7 +11,7 @@ module ErrorMessageFlash
   end
 
   def get_word_message(action_name)
-    text = "ワードの#{action_name}に失敗しました。"
+    text = "ワードの#{action_name}に失敗しました。入力に誤りがあります。"
     return text
   end
 

--- a/app/controllers/concerns/error_message_flash.rb
+++ b/app/controllers/concerns/error_message_flash.rb
@@ -25,6 +25,11 @@ module ErrorMessageFlash
     return text
   end
 
+  def get_reputation_message_incident
+    text = "評価登録の処理に失敗しました。管理者にお問合せください。"
+    return text
+  end
+
 end
 
 

--- a/app/controllers/concerns/error_message_flash.rb
+++ b/app/controllers/concerns/error_message_flash.rb
@@ -1,0 +1,31 @@
+module ErrorMessageFlash
+  extend ActiveSupport::Concern
+
+  def reset_flash
+    flash[:alert] = ''
+  end
+
+  def get_point_message(requested_point,action_name)
+    text = "ワードポイントが#{requested_point - @word_point}ポイント足りません。#{action_name}には#{requested_point}ポイントが必要です。"
+    return text
+  end
+
+  def get_word_message(action_name)
+    text = "ワードの#{action_name}に失敗しました。"
+    return text
+  end
+
+  def get_word_message_incident(action_name)
+    text = "ワードの#{action_name}に失敗しました。管理者にお問合せください。"
+    return text
+  end
+
+  def get_no_word_message()
+    text ='交換するワードがありません。他のユーザーがワードを登録するのをお待ちください。'
+    return text
+  end
+
+end
+
+
+

--- a/app/controllers/exchanged_words_controller.rb
+++ b/app/controllers/exchanged_words_controller.rb
@@ -9,7 +9,7 @@ class ExchangedWordsController < ApplicationController
   include PointMethod
   before_action :check_requested_point, only:[:create]
   include ErrorMessageFlash
-  before_action :reset_flash, only:[:new]
+  before_action :reset_flash
   WORD_NUM = 2
   RANDOM_SEED = 17
 
@@ -28,7 +28,7 @@ class ExchangedWordsController < ApplicationController
         decrease_point(requested_point)
         redirect_to user_exchanged_words_path(current_user.id)
       else
-        flash.now[:alert] = get_point_message(requested_point, "交換")
+        flash.now[:alert] = get_word_message_incident(requested_point, "交換")
         render :new
       end
     else

--- a/app/controllers/exchanged_words_controller.rb
+++ b/app/controllers/exchanged_words_controller.rb
@@ -8,6 +8,7 @@ class ExchangedWordsController < ApplicationController
   before_action :set_category, only: [:index, :show]
   include PointMethod
   before_action :check_requested_point, only:[:create]
+  before_action :reset_flash, only:[:new]
   WORD_NUM = 2
   RANDOM_SEED = 17
 
@@ -26,9 +27,11 @@ class ExchangedWordsController < ApplicationController
         decrease_point(requested_point)
         redirect_to user_exchanged_words_path(current_user.id)
       else
+        flash.now[:alert] = '交換に失敗しました。管理者にお問合せください。'
         render :new
       end
     else
+      flash[:alert] = '交換するワードがありません。他のユーザーがワードを登録するのをお待ちください。'
       render :new
     end
   end
@@ -90,6 +93,13 @@ class ExchangedWordsController < ApplicationController
 
   def check_requested_point
     requested_point = ENV["WORD_POINT_EXCHANGE"].to_i
-    render :new if have_decrease_error?(requested_point)
+    if have_decrease_error?(requested_point)
+      flash[:alert] = "ワードポイントが#{requested_point - @word_point}ポイント足りません。交換には#{requested_point}ポイントが必要です。"
+      render :new 
+    end
+  end
+
+  def reset_flash
+    flash[:alert] = ''
   end
 end

--- a/app/controllers/exchanged_words_controller.rb
+++ b/app/controllers/exchanged_words_controller.rb
@@ -32,7 +32,7 @@ class ExchangedWordsController < ApplicationController
         render :new
       end
     else
-      flash[:alert] = get_no_word_message()
+      flash.now[:alert] = get_no_word_message()
       render :new
     end
   end
@@ -95,7 +95,7 @@ class ExchangedWordsController < ApplicationController
   def check_requested_point
     requested_point = ENV["WORD_POINT_EXCHANGE"].to_i
     if have_decrease_error?(requested_point)
-      flash[:alert] = get_point_message(requested_point, "交換")
+      flash.now[:alert] = get_point_message(requested_point, "交換")
       render :new 
     end
   end

--- a/app/controllers/exchanged_words_controller.rb
+++ b/app/controllers/exchanged_words_controller.rb
@@ -8,6 +8,7 @@ class ExchangedWordsController < ApplicationController
   before_action :set_category, only: [:index, :show]
   include PointMethod
   before_action :check_requested_point, only:[:create]
+  include ErrorMessageFlash
   before_action :reset_flash, only:[:new]
   WORD_NUM = 2
   RANDOM_SEED = 17
@@ -27,11 +28,11 @@ class ExchangedWordsController < ApplicationController
         decrease_point(requested_point)
         redirect_to user_exchanged_words_path(current_user.id)
       else
-        flash.now[:alert] = '交換に失敗しました。管理者にお問合せください。'
+        flash.now[:alert] = get_point_message(requested_point, "交換")
         render :new
       end
     else
-      flash[:alert] = '交換するワードがありません。他のユーザーがワードを登録するのをお待ちください。'
+      flash[:alert] = get_no_word_message()
       render :new
     end
   end
@@ -94,12 +95,9 @@ class ExchangedWordsController < ApplicationController
   def check_requested_point
     requested_point = ENV["WORD_POINT_EXCHANGE"].to_i
     if have_decrease_error?(requested_point)
-      flash[:alert] = "ワードポイントが#{requested_point - @word_point}ポイント足りません。交換には#{requested_point}ポイントが必要です。"
+      flash[:alert] = get_point_message(requested_point, "交換")
       render :new 
     end
   end
 
-  def reset_flash
-    flash[:alert] = ''
-  end
 end

--- a/app/controllers/good_reputations_controller.rb
+++ b/app/controllers/good_reputations_controller.rb
@@ -4,6 +4,8 @@ class GoodReputationsController < ApplicationController
   include CheckRedirector
   before_action :check_user_id, only: [:create]
   before_action :check_exchanged_word_id_for_reputation, only: [:create]
+  include ErrorMessageFlash
+  before_action :reset_flash, only: [:create]
 
   def create
     insert_or_change_good_reputation
@@ -12,6 +14,7 @@ class GoodReputationsController < ApplicationController
     else
       @exchanged_words = ExchangedWord.where(user_id: current_user.id).order('created_at DESC')
       set_category
+      flash.now[:alert] = get_reputation_message_incident
       render 'exchanged_words/index'
     end
   end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -92,6 +92,13 @@ class WordsController < ApplicationController
     @word = Word.find_by(user_id: params[:user_id],id: params[:id])
   end
 
+  def re_set_word
+    writting_word = Word.new(params.require(:word).permit(:name, :main_category_id, :service_category_id))
+    @word.name = writting_word.name
+    @word.main_category_id = writting_word.main_category_id
+    @word.service_category_id = writting_word.service_category_id
+  end
+
   def create_or_add_point
     if WordPoint.exists?(user_id: current_user.id)
       add_point(ENV["WORD_POINT_CREATE"].to_i)
@@ -104,6 +111,7 @@ class WordsController < ApplicationController
     requested_point = ENV["WORD_POINT_UPDATE"].to_i
     if have_decrease_error?(requested_point)
       set_category
+      re_set_word
       flash[:alert] = get_point_message(requested_point, "更新")
       render :edit
     end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -10,6 +10,7 @@ class WordsController < ApplicationController
   include PointMethod
   before_action :check_requested_point_update, only:[:update]
   before_action :check_requested_point_destroy, only:[:destroy]
+  before_action :reset_flash, only:[:new]
 
   def index
     @words = Word.where(user_id: current_user.id).order('updated_at DESC')
@@ -25,6 +26,7 @@ class WordsController < ApplicationController
       redirect_to user_words_path(current_user.id)
     else
       @words.new_set_data
+      flash.now[:alert] = 'ワードの登録に失敗しました。登録済のワードと重複している、またはプルダウンを選択していない可能性があります。'
       render :new
     end
   end
@@ -38,6 +40,7 @@ class WordsController < ApplicationController
       redirect_to user_words_path(current_user.id)
     else
       set_category
+      flash.now[:alert] = 'ワードの更新に失敗しました。登録済のワードと重複している可能性があります。'
       render :edit
     end
   end
@@ -48,6 +51,7 @@ class WordsController < ApplicationController
       redirect_to user_words_path(current_user.id)
     else
       set_category
+      flash.now[:alert] = 'ワードの削除に失敗しました。管理者にお問合せください。'
       render :edit
     end
   end
@@ -89,6 +93,7 @@ class WordsController < ApplicationController
     requested_point = ENV["WORD_POINT_UPDATE"].to_i
     if have_decrease_error?(requested_point)
       set_category
+      flash[:alert] = "ワードポイントが#{requested_point - @word_point}ポイント足りません。更新には#{requested_point}ポイントが必要です。"
       render :edit
     end
   end
@@ -97,7 +102,12 @@ class WordsController < ApplicationController
     requested_point = ENV["WORD_POINT_DESTROY"].to_i
     if have_decrease_error?(requested_point)
       set_category
+      flash[:alert] = "ワードポイントが#{requested_point - @word_point}ポイント足りません。削除には#{requested_point}ポイントが必要です。"
       render :edit
     end
+  end
+
+  def reset_flash
+    flash[:alert] = ''
   end
 end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -22,11 +22,11 @@ class WordsController < ApplicationController
   end
 
   def create
-    if @words.save_data(words_params)
+    if @words.save_data(words_save_params)
       create_or_add_point
       redirect_to user_words_path(current_user.id)
     else
-      @words.new_set_data
+      @words.set_data(words_set_params)
       flash.now[:alert] = get_word_message("登録")
       render :new
     end
@@ -58,13 +58,23 @@ class WordsController < ApplicationController
   end
 
   private
-  def words_params
+  def words_save_params
     return params.require(:words).map do |word|
       word.permit(
         :name,
         :main_category_id,
         :service_category_id
       ).merge(user_id: current_user.id)
+    end
+  end
+
+  def words_set_params
+    return params.require(:words).map do |word|
+      word.permit(
+        :name,
+        :main_category_id,
+        :service_category_id
+      )
     end
   end
 

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -11,7 +11,7 @@ class WordsController < ApplicationController
   before_action :check_requested_point_update, only:[:update]
   before_action :check_requested_point_destroy, only:[:destroy]
   include ErrorMessageFlash
-  before_action :reset_flash, only:[:create, :update, :destroy]
+  before_action :reset_flash
 
   def index
     @words = Word.where(user_id: current_user.id).order('updated_at DESC')

--- a/app/models/word_collection.rb
+++ b/app/models/word_collection.rb
@@ -11,6 +11,12 @@ class WordCollection
     self.collection = WORD_NUM.times.map{ Word.new }
   end
 
+  def set_data(params)
+    self.collection = WORD_NUM.times.map do |n|
+      Word.new(params[n])
+    end
+  end
+
   def save_data(params)
     is_success = true
     ActiveRecord::Base.transaction do

--- a/app/views/exchanged_words/index.html.erb
+++ b/app/views/exchanged_words/index.html.erb
@@ -21,6 +21,10 @@
       </div>
     </div>
 
+    <div class="alert_message">
+      <%= flash[:alert] %>
+    </div>
+
     <%= form_with local: true do |form| %>
       <% @exchanged_words.each do |exchanged_word| %>
         <hr size="1" width="98%" noshade="">

--- a/app/views/exchanged_words/new.html.erb
+++ b/app/views/exchanged_words/new.html.erb
@@ -20,8 +20,10 @@
         ・現在、エラー表示等の機能は実装できていません。ご不便をおかけいたします。
       </div>
     </div>
-
-    <%= flash[:alert] %>
+    
+    <div class="alert_message">
+      <%= flash[:alert] %>
+    </div>
 
     <%= form_with class: "exchanged_word_new_box", url: user_exchanged_words_path, method: :post, local: true do |form| %>
       <%= form.submit '交換',class:"exchanged_word_new_button" %>

--- a/app/views/exchanged_words/new.html.erb
+++ b/app/views/exchanged_words/new.html.erb
@@ -21,8 +21,9 @@
       </div>
     </div>
 
+    <%= flash[:alert] %>
+
     <%= form_with class: "exchanged_word_new_box", url: user_exchanged_words_path, method: :post, local: true do |form| %>
-      <%# <%= form.number_field :num, value: 1 ,in: 1..5, class: "" %>
       <%= form.submit '交換',class:"exchanged_word_new_button" %>
     <% end %>
     

--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -11,6 +11,8 @@
       "ワード" 編集
     </h3>
 
+    <%= flash[:alert] %>
+
     <%= form_with(model: @word, url: user_word_path(@word.user_id, @word),class: "word_edit_list", local: true) do |form| %>
 
       <%= render 'shared/error_messages', model: form.object %>

--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -11,7 +11,9 @@
       "ワード" 編集
     </h3>
 
-    <%= flash[:alert] %>
+    <div class="alert_message">
+      <%= flash[:alert] %>
+    </div>
 
     <%= form_with(model: @word, url: user_word_path(@word.user_id, @word),class: "word_edit_list", local: true) do |form| %>
 

--- a/app/views/words/new.html.erb
+++ b/app/views/words/new.html.erb
@@ -25,6 +25,8 @@
       </div>
     </div>
 
+    <%= flash[:alert] %>
+
     <%= form_with class: "word_new_list", modele: @words, url: user_words_path, method: :post, local: true do |form| %>
       <% @words.collection.each do |word| %>
         <%= fields_for 'words[]', word do |field| %>

--- a/app/views/words/new.html.erb
+++ b/app/views/words/new.html.erb
@@ -29,7 +29,8 @@
       <%= flash[:alert] %>
     </div>
 
-    <%= form_with class: "word_new_list", modele: @words, url: user_words_path, method: :post, local: true do |form| %>
+    <%= form_with class: "word_new_list", model: @words, url: user_words_path, method: :post, local: true do |form| %>
+      <%= render 'shared/error_messages', model: form.object %>
       <% @words.collection.each do |word| %>
         <%= fields_for 'words[]', word do |field| %>
           <hr size="1" width="99%">

--- a/app/views/words/new.html.erb
+++ b/app/views/words/new.html.erb
@@ -25,7 +25,9 @@
       </div>
     </div>
 
-    <%= flash[:alert] %>
+    <div class="alert_message">
+      <%= flash[:alert] %>
+    </div>
 
     <%= form_with class: "word_new_list", modele: @words, url: user_words_path, method: :post, local: true do |form| %>
       <% @words.collection.each do |word| %>


### PR DESCRIPTION
# What
入力またはシステムエラーの際、表示するメッセージをflashを用いて実装

# Why
バリデーション時、またはワードポイントが足りない際、なぜ処理が進まないのかがユーザーにとってわからない状態だったため、実装を行うことにした。

# 補足事項
ワード一括登録の際、エラーメッセージは表示されるが、どの項目でエラーとなっているかの識別ができない状態。これを実装しようとすると、非常に大きな改修となってしまうため、今回は保留となった。