### PR TITLE
交換ボタンの処理を修正

### DIFF
--- a/app/controllers/concerns/point_method.rb
+++ b/app/controllers/concerns/point_method.rb
@@ -11,13 +11,13 @@ module PointMethod
   end
 
   def set_word_point_display
-    @word_point = if !user_signed_in?
-                    'Login Please'
-                  elsif WordPoint.exists?(user_id: current_user.id)
-                    WordPoint.find_by(user_id: current_user.id).point
-                  else
-                    '0'
-                  end
+    if !user_signed_in?
+      @word_point = 'Login Please'
+    elsif WordPoint.exists?(user_id: current_user.id)
+      @word_point = WordPoint.find_by(user_id: current_user.id).point
+    else
+      @word_point = 0
+    end
   end
 
   def create_point

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,9 +3,9 @@
   
   <div>
     <ul class="links">
-      <li><a href="#" class="link">お問合せ</a></li>
-      <li><a href="#" class="link">マニュアル</a></li>
-      <li><a href="#" class="link">About</a></li>
+      <%= link_to "お問合せ", "#", class: "link" %>
+      <%= link_to "マニュアル", "https://www.youtube.com/watch?v=16QIaHYuxUQ", class: "link", target: :_blank, rel: "noopener noreferrer" %>
+      <%= link_to "About", "#", class: "link" %>
     </ul>
   </div>
   

--- a/app/views/shared/_side_bar.html.erb
+++ b/app/views/shared/_side_bar.html.erb
@@ -50,8 +50,13 @@
         </button>
         <div class="collapse" id="home-collapse">
           <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-            <li><a href="#" class="link-dark rounded">プロフィール</a></li>
-            <li><a href="#" class="link-dark rounded">パスワード変更</a></li>
+            <% if user_signed_in? %>
+              <%= link_to 'プロフィール', edit_user_registration_path, class: "link-dark rounded" %>
+              <%= link_to 'パスワード変更', root_path, class: "link-dark rounded" %>
+            <% elsif %>
+              <%= link_to 'プロフィール', user_session_path, class: "link-dark rounded" %>
+              <%= link_to 'パスワード変更', user_session_path, class: "link-dark rounded" %>
+            <% end %>
           </ul>
         </div>
       </li>


### PR DESCRIPTION
# What
ワードポイント取得メソッドにある「ゼロ」ポイントを、文字列から整数型に修正

# Why
ユーザー登録初回時、交換ボタンを押すと、エラーとなってしまう問題を修正するため

# 補足
ヘッダーとサイドバーを修正してしまいました。