### PR TITLE
生年月日の年の順番を入れ替え

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -63,8 +63,8 @@
                           id:"birth-date",
                           use_month_numbers: true,
                           prompt:'--',
-                          start_year: 1930,
-                          end_year: (Time.now.year - 5),
+                          start_year: (Time.now.year - 5),
+                          end_year: 1930,
                           date_separator: '%s'),
                         "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -78,8 +78,8 @@
                     id:"birth-date",
                     use_month_numbers: true,
                     prompt:'--',
-                    start_year: 1930,
-                    end_year: (Time.now.year - 5),
+                    start_year: (Time.now.year - 5),
+                    end_year: 1930,
                     date_separator: '%s'),
                   "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
     </div>


### PR DESCRIPTION
# What
生年月日の年の順番を入れ替え（降順となるように設定）

# Why
利用している人の大半が1990年代前後なので、順番を入れ替えてユーザービリティー向上を図るため