### PR TITLE
高さをメインスクリーンと同じ高さへ調整

### DIFF
--- a/app/assets/stylesheets/shared/main.css
+++ b/app/assets/stylesheets/shared/main.css
@@ -28,7 +28,6 @@
 .main_screen {
   width: calc(100% - 240px);
   height: 100%;
-  padding: 10px;
   background-color: #fcf5f3;
   border-radius: 0 10px 10px 0;
   display: flex;


### PR DESCRIPTION
# What
サイドバーの高さとメインスクリーンの高さを合わせるため、メインスクリーンのpaddingのプロパティを削除

# Why
サイドバーとメインスクリーンの高さが、paddng分ずれていたため