### PR TITLE
高さをWebブラウザ全体に大きくなるよう調整

### DIFF
--- a/app/assets/stylesheets/shared/main.css
+++ b/app/assets/stylesheets/shared/main.css
@@ -14,7 +14,7 @@
 .split_main {
   display: flex;
   justify-content: left;
-  height: 600px;
+  height: calc(100vh - 91px);
 }
 
 .sidebar {


### PR DESCRIPTION
# What 
メインページの高さを調整

# Why
ユーザーから指摘を受けたため
高さが固定化になっていたため、大きなディスプレイでアプリ使用すると、デザインが損なわれるため修正