### PR TITLE
デザインが崩れる問題を修正

### DIFF
--- a/app/assets/stylesheets/shared/main.css
+++ b/app/assets/stylesheets/shared/main.css
@@ -93,14 +93,14 @@
 
   .header, .header_back{
     position: absolute;
-    top: -50vh;
+    top: -300vh;
   }
 
   input[type="checkbox"]:checked ~ .header{
     top: 0;
     left: 0;
     width: 100%;
-    transition: all 0.2s;
+    transition: all 0.1s;
     z-index: 100;
   }
 
@@ -110,14 +110,14 @@
     left: 0;
     width: 100%;
     height: 130vh;
-    transition: all 0.2s;
+    transition: all 0.1s;
     background-color: rgba(0,0,0,0.8);
     z-index: 100;
   }
 
   .sidebar, .sidebar_back{
     position: absolute;
-    left: -100vw;
+    left: -300vw;
   }
 
   input[type="checkbox"]:checked ~ .sidebar{
@@ -125,7 +125,7 @@
     left: 0;
     width: 70%;
     height: 130vh;
-    transition: all 0.2s;
+    transition: all 0.1s;
     z-index: 100;
   }
 
@@ -135,7 +135,7 @@
     left: 70%;
     width: 30%;
     height: 130vh;
-    transition: all 0.2s;
+    transition: all 0.1s;
     background-color: rgba(0,0,0,0.8);
     z-index: 100;
   }


### PR DESCRIPTION
# What
ブラウザの画面が小さくなった際、ヘッダー部分が画面上に表示されてしまう問題を修正。
それに伴い、transitionのパラメータも修正

# Why
スマホ用に実装した機能をもとに、PCのブラウザで、画面サイズを小さくすると、デザインが崩れてしまう問題を発見したために、修正する必要があったから
