### PR TITLE
パスワード変更のテキストフォームのデザイン修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -111,16 +111,16 @@
               <label class="user_info_form_content">新しいパスワード</label>
               <span class="user_info_form_need">必須</span>
             </div>
-            <%= f.password_field :password, class:"input-default", id:"password", placeholder:"" %>
-            <p class='info-text'>※6文字以上の英字と数字の両方を含めてください</p>
+            <%= f.password_field :password, class:"user_info_form_text_field", id:"password", placeholder:"" %>
+            <p class='user_info_text'>※6文字以上の英字と数字の両方を含めてください</p>
           </div>
           <div class="user_info_form">
             <div class='user_info_form_title'>
               <label class="user_info_form_content">新しいパスワード(再度確認)</label>
               <span class="user_info_form_need">必須</span>
             </div>
-            <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"" %>
-            <p class='info-text'>※同じパスワードをもう一度、入力してください</p>
+            <%= f.password_field :password_confirmation, class:"user_info_form_text_field", id:"password-confirmation", placeholder:"" %>
+            <p class='user_info_text'>※同じパスワードをもう一度、入力してください</p>
           </div>
         </div>
         <%= f.submit "更新" ,class:"user_info_btn", id:"orange_button" %>


### PR DESCRIPTION
# What
パスワード変更のフォームデザイン修正

# Why
本番環境のパスワード変更のページを確認すると、フォームが崩れていたため。
調査したところ、2022年12月31日に、ユーザー新規登録画面とログイン画面のデザインを修正した際、該当するCSSソースコードを削除し、新たにCSSファイルを作っていたことがわかった。
パスワード変更フォームのクラス名が、削除したソースコードのセレクタ名を呼び出す形となっていたことが原因。