### PR TITLE
設定値追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,4 +122,7 @@ Rails.application.configure do
     authentication:  :plain,
     enable_starttls_auto:  true
   }
+
+  # SSL-redirector
+  config.force_ssl = true
 end


### PR DESCRIPTION
# What
productionにリダイレクト設定を追加

# Why
HTTPでの利用は情報流出の恐れがあるため