### PR TITLE
DXアセスメントのリンクをサイドバーへ追加

### DIFF
--- a/app/views/shared/_side_bar.html.erb
+++ b/app/views/shared/_side_bar.html.erb
@@ -60,10 +60,11 @@
 </div>
 
 <div class="side_bar_block">
-  <label class="side_bar_title_header">その他の作品</label>
+  <label class="side_bar_title_header">その他の作品・情報</label>
   <div class="side_bar_contents">
     <%= link_to 'ETロボコン映像', etrobocons_index_path, class: "side_bar_content" %>
     <%= link_to 'FingerPrinting', devicefingerprinting_index_path, class: "side_bar_content" %>
+    <%= link_to 'DXアセスメント結果', "https://drive.google.com/file/d/1GYUX-JE-5ok5EYTve9doI0Otv7ayNqYC/view?usp=share_link", class: "side_bar_content" %>
   </div>
 </div>
 


### PR DESCRIPTION
# What
DXアセスメントの項目をサイドバーへ追加

# Why
エンジニアとしてのDXのレベルを採用担当者へ情報提供させるため
